### PR TITLE
Poisoning

### DIFF
--- a/code/headers/frame_types.hpp
+++ b/code/headers/frame_types.hpp
@@ -32,9 +32,8 @@
  * using structs that are meant purely for the
  * Python bus
  */ 
-#define R2D2_POISON_TYPE_HELPER0(x) R2D2_TO_STRING(GCC poison x)
-#define R2D2_POISON_TYPE_HELPER1(x) R2D2_POISON_TYPE_HELPER0(x)
-#define R2D2_POISON_TYPE(Type) _Pragma(R2D2_POISON_TYPE_HELPER1(Type))
+#define R2D2_POISON_TYPE_HELPER(x) R2D2_TO_STRING(GCC poison x)
+#define R2D2_POISON_TYPE(Type) _Pragma(R2D2_POISON_TYPE_HELPER(Type))
 
 #define R2D2_INTERNAL_FRAME_HELPER(Type, EnumVal, ...) \
     template<> \

--- a/code/headers/frame_types.hpp
+++ b/code/headers/frame_types.hpp
@@ -15,6 +15,9 @@
  * is an exception. It is possible there will be another exception for 
  * the robos instructions later.
  */
+#define R2D2_STRINGIFY(x) #x
+#define R2D2_TO_STRING(x) R2D2_STRINGIFY(x)
+
 #define R2D2_OPTIMISE_STRING(Type, MemberName) \
     template<> \
     struct supports_string_optimisation<Type> : std::true_type {}; \
@@ -24,6 +27,14 @@
         constexpr static uint16_t offset = offsetof(Type, MemberName); \
     };
 
+/**
+ * Poisioning is used to prevent people from
+ * using structs that are meant purely for the
+ * Python bus
+ */ 
+#define R2D2_POISON_TYPE_HELPER0(x) R2D2_TO_STRING(GCC poison x)
+#define R2D2_POISON_TYPE_HELPER1(x) R2D2_POISON_TYPE_HELPER0(x)
+#define R2D2_POISON_TYPE(Type) _Pragma(R2D2_POISON_TYPE_HELPER1(Type))
 
 #define R2D2_INTERNAL_FRAME_HELPER(Type, EnumVal, ...) \
     template<> \
@@ -53,6 +64,9 @@
 // Empty define
 #define R2D2_PACK_STRUCT
 #endif
+
+// Tag that indicates that the frame is meant for Python only
+#define R2D2_PYTHON_FRAME
 
 namespace r2d2 {
     /**
@@ -298,7 +312,7 @@ namespace r2d2 {
      * SwarmUI wiki:
      * https://github.com/R2D2-2019/R2D2-2019/wiki/Swarm-UI    
      */
-    R2D2_PACK_STRUCT
+    R2D2_PYTHON_FRAME
     struct frame_ui_command_s {
         // module is the name of the targeted module, mostly used 
         // to prevent nameclash
@@ -360,7 +374,7 @@ namespace r2d2 {
     R2D2_INTERNAL_FRAME_HELPER(frame_distance_s, DISTANCE)
     R2D2_INTERNAL_FRAME_HELPER(frame_display_filled_rectangle_s, DISPLAY_FILLED_RECTANGLE)
     R2D2_INTERNAL_FRAME_HELPER(frame_battery_level_s, BATTERY_LEVEL)
-    R2D2_INTERNAL_FRAME_HELPER(frame_ui_command_s, UI_COMMAND)
+    R2D2_INTERNAL_FRAME_HELPER(frame_ui_command_s, UI_COMMAND, R2D2_POISON_TYPE(frame_ui_command_s))
     R2D2_INTERNAL_FRAME_HELPER(frame_movement_control_s, MOVEMENT_CONTROL)
 
     // EXAMPLE: for string optimalisation, the frame doesn't actually support it

--- a/code/headers/frame_types.hpp
+++ b/code/headers/frame_types.hpp
@@ -32,8 +32,7 @@
  * using structs that are meant purely for the
  * Python bus
  */ 
-#define R2D2_POISON_TYPE_HELPER(x) R2D2_TO_STRING(GCC poison x)
-#define R2D2_POISON_TYPE(Type) _Pragma(R2D2_POISON_TYPE_HELPER(Type))
+#define R2D2_POISON_TYPE(Type) _Pragma(R2D2_TO_STRING(GCC poison Type))
 
 #define R2D2_INTERNAL_FRAME_HELPER(Type, EnumVal, ...) \
     template<> \


### PR DESCRIPTION
This PR allows a frame to be marked as a "Python" frame. This prevents the struct from being used in other parts of the system, as it should not be.