### PR TITLE
char fix for proper python conversion

### DIFF
--- a/code/headers/frame_types.hpp
+++ b/code/headers/frame_types.hpp
@@ -797,7 +797,7 @@ namespace r2d2 {
      */
     R2D2_PYTHON_FRAME
     struct frame_qrcode_data_s {
-        char[] message;
+        char message[200];
         uint16_t width;
         uint16_t height;
         int16_t x_offset;

--- a/code/headers/frame_types.hpp
+++ b/code/headers/frame_types.hpp
@@ -797,7 +797,7 @@ namespace r2d2 {
      */
     R2D2_PYTHON_FRAME
     struct frame_qrcode_data_s {
-        char message;
+        char[] message;
         uint16_t width;
         uint16_t height;
         int16_t x_offset;


### PR DESCRIPTION
Char is converted to 'c' in in Python which is a single character. char[] is converted to 's' (string) which is what we need.